### PR TITLE
Added systemd service and README about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,16 @@
 A simple script to keep Cloudlog in synch with WSJTX's logbook. As soon as a qso is saved in WSJTX it is sent to Cloudlog as well. 
 Additionally the current frequency and mode are send to Cloudlog, if you want todo live logging, directly in Cloudlog. 
 
-Installation:
+## Installation
  copy the script and this config file in a directory
  add the script in your crontab, so it is called at system start
  add the logfile to /etc/logrotate.d/rsyslog
 
+## Systemd installation
+ - create unprivileged user `useradd -m -r -d /opt/wsjtx_log -g nobody -s /usr/bin/nologin wsjtxlog`
+ - copy script and config into `cp wsjtx_log.pl wsjtx_log.conf /opt/wsjtx_log/`
+ - copy service `cp wsjtx_log.service /lib/systemd/system`
+ - reload systemd `systemctl daemon-reload`
+ - run service `systemctl start wsjtx_log`
+ - for logs check journal `journalctl -fu wsjtx_log`
+ - for autostart after reboot use `systemd enable wsjtx_log`

--- a/wsjtx_log.service
+++ b/wsjtx_log.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=WSJTX CloudLog
+After=network.target
+
+[Service]
+ExecStart=/opt/wsjtx_log/wsjtx_log.pl
+User=wsjtxlog
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Because using crontab "reboot" to run service is really NOT recommended way how to run service. I added systemd service for it.. And because I am not fan of running processes under root (if that is not really needed) I did readme about create system user for this daemon.

But if someone does not concert security, they can just rewrite "User" field in systemd.service for whatever they want (root, their username, pi, ...). Because this daemon does not need write access to anywhere, it is no matter what user will run it, even nobody user would be fine too if it has access to folder to run script